### PR TITLE
up nox version

### DIFF
--- a/.github/workflows/test-compatibility.yaml
+++ b/.github/workflows/test-compatibility.yaml
@@ -33,4 +33,4 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Run tests
-        run: uvx --with "nox[pbs]" nox -s compatibility
+        run: uvx nox -s compatibility

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,10 +1,8 @@
 import nox
 
-PYTHON_SUPPORT_VERSIONS = ("3.9", "3.10", "3.11", "3.12", "3.13", "3.14")
 
-
-@nox.session(python=PYTHON_SUPPORT_VERSIONS)
-@nox.parametrize("fastapi", ("0.100.0", "latest"))
+@nox.session(python=None)
+@nox.parametrize("fastapi", ["0.100.0", "latest"])
 def compatibility(session, fastapi):
     session.run("uv", "sync", "--locked", "--group", "test", "--active", external=True)
 


### PR DESCRIPTION
Hello
In PR add matrix all support python versions(3.9-3.14) and fastapi (min and max) by default.