### PR TITLE
Release 0.9.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,15 +7,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync --locked --group all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         run: uv sync --locked --group all
 
       - name: Lint code
-        run: uv run make code.lint
+        run: uv run make lint
 
       - name: Run tests for Codecov
         run: uv run pytest --cov=fastapi_error_map --cov-branch --cov-report=xml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,59 @@
+name: Publish to PyPI on GitHub Release
+
+on:
+  release:
+    types: [ published ]
+
+env:
+  UV_PYTHON_DOWNLOADS: 0
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    permissions: { }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build
+        run: uv build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: python-package-distributions
+          path: dist/*
+
+  publish:
+    name: Publish to PyPI (OIDC)
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Publish
+        run: uv publish

--- a/.github/workflows/test-compatibility.yaml
+++ b/.github/workflows/test-compatibility.yaml
@@ -23,14 +23,16 @@ jobs:
           - "3.14"
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Set up ${{ matrix.python-version }} on ${{ matrix.os }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Run tests
         run: uvx nox -s compatibility

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: local
     hooks:
-      - id: make-check
-        name: source-code-check
-        entry: make code.check
+      - id: code-check
+        name: code-check (local)
+        entry: uv run make check
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,24 @@
-# Code quality
-.PHONY: code.format code.lint code.test code.cov code.cov.html code.check
-code.format:
-	ruff format
+# Make config
+.SILENT:
+MAKEFLAGS += --no-print-directory
 
-code.lint: code.format
-	ruff check --exit-non-zero-on-fix
+# Code quality
+.PHONY: lint test check coverage
+lint:
+	ruff check --fix
+	ruff format
 	mypy
 
-code.test:
+test:
 	pytest -v
 
-code.cov:
-	coverage run -m pytest
-	coverage combine
-	coverage report
+check: lint test
 
-code.cov.html:
-	coverage run -m pytest
-	coverage combine
+coverage: check
 	coverage html
 
-code.check: code.lint code.test
+# Project structure visualization
+.PHONY: pycache-del
+pycache-del:
+	find . -type d -name '__pycache__' -prune -exec rm -rf {} +; \
+	find . -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete

--- a/README.md
+++ b/README.md
@@ -142,10 +142,13 @@ Parameters of `rule(...)`, * — required:
 
 #### 🧩 Matching semantics
 
-`error_map` matches **exact** exception types only (no inheritance).
-If you map `BaseError` and raise `ChildError(BaseError)`, the rule won’t apply.
-This is by design to keep routing explicit.
-If there’s demand, inheritance-based resolving may be added later as an opt-in.
+`error_map` resolves exceptions using Python's Method Resolution Order (MRO).
+The most specific exception type is matched first.
+If no exact match is found, parent classes are checked in MRO order.
+
+For example, if you map `BaseError` and raise `ChildError(BaseError)`,
+the rule for `BaseError` will apply — unless a specific rule for
+`ChildError` is defined, in which case it takes precedence.
 
 ### 🧰 Custom Translators
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ In addition to `error_map`, you can also pass:
     warn_on_unmapped=...,
     default_client_error_translator=...,
     default_server_error_translator=...,
+    exclude_none=...,
 )
 ```
 
@@ -274,6 +275,11 @@ When an error occurs, `fastapi-error-map` processes it as follows:
     - If provided in `rule(...)`, it is used
     - Otherwise, `default_on_error` is used if provided
     - If neither is set, nothing is called
+
+4. `exclude_none`:
+    - If `True`, fields with value `None` are omitted from the serialized
+      error response body
+    - If `False` (default), `None` values are included as `null`
 
 #### 🧾 OpenAPI: `responses` Takes Priority
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,4 +11,4 @@ def compatibility(session, fastapi):
     else:
         session.run("uv", "add", f"fastapi=={fastapi}", "--active", external=True)
 
-    session.run("uv", "run", "--active", "make", "code.test", external=True)
+    session.run("uv", "run", "--active", "make", "test", external=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ sources = ["src"]
 
 [project]
 name = "fastapi-error-map"
-version = "0.9.8"
+version = "0.9.9"
 description = "Elegant per-endpoint error handling for FastAPI that keeps OpenAPI in sync"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -92,6 +92,7 @@ parallel = true
 branch = true
 
 [tool.mypy]
+python_version = "3.9"
 files = [
     "examples",
     "src",
@@ -114,6 +115,7 @@ asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 88
+target-version = "py39"
 preview = true  # experimental
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ testpaths = ["tests", ]
 markers = ["slow", ]
 addopts = "-m 'not slow'"
 asyncio_default_fixture_loop_scope = "function"
+asyncio_mode = "auto"
 
 [tool.ruff]
 line-length = 88

--- a/src/fastapi_error_map/error_handling.py
+++ b/src/fastapi_error_map/error_handling.py
@@ -19,6 +19,7 @@ def wrap_with_error_handling(
     default_client_error_translator: ErrorTranslator[Any],
     default_server_error_translator: ErrorTranslator[Any],
     default_on_error: Optional[Callable[[Exception], Union[Awaitable[None], None]]],
+    exclude_none: bool = False,
 ) -> Callable[..., Any]:
     is_coro = inspect.iscoroutinefunction(func)
 
@@ -36,6 +37,7 @@ def wrap_with_error_handling(
                 default_client_error_translator=default_client_error_translator,
                 default_server_error_translator=default_server_error_translator,
                 default_on_error=default_on_error,
+                exclude_none=exclude_none,
             )
 
     return wrapped
@@ -49,6 +51,7 @@ async def handle_with_error_map(
     default_client_error_translator: ErrorTranslator[Any],
     default_server_error_translator: ErrorTranslator[Any],
     default_on_error: Optional[Callable[[Exception], Union[Awaitable[None], None]]],
+    exclude_none: bool,
 ) -> ORJSONResponse:
     try:
         rule = resolve_rule_for_error(
@@ -75,5 +78,8 @@ async def handle_with_error_map(
     content = rule.translator.from_error(error)
     return ORJSONResponse(
         status_code=rule.status,
-        content=jsonable_encoder(content),
+        content=jsonable_encoder(
+            content,
+            exclude_none=exclude_none,
+        ),
     )

--- a/src/fastapi_error_map/error_handling.py
+++ b/src/fastapi_error_map/error_handling.py
@@ -27,7 +27,7 @@ def wrap_with_error_handling(
         try:
             if is_coro:
                 return await func(*args, **kwargs)
-            return func(*args, **kwargs)
+            return await run_in_threadpool(func, *args, **kwargs)
         except Exception as error:
             return await handle_with_error_map(
                 error=error,

--- a/src/fastapi_error_map/routing.py
+++ b/src/fastapi_error_map/routing.py
@@ -48,6 +48,7 @@ class ErrorAwareRoute(APIRoute):
         warn_on_unmapped: bool = True,
         default_client_error_translator: Optional[ErrorTranslator[Any]] = None,
         default_server_error_translator: Optional[ErrorTranslator[Any]] = None,
+        exclude_none: bool = False,
         # --- FastAPI ---
         response_model: Any = Default(None),
         status_code: Optional[int] = None,
@@ -98,6 +99,7 @@ class ErrorAwareRoute(APIRoute):
                 default_on_error=self.default_on_error,
                 default_client_error_translator=self.default_client_error_translator,
                 default_server_error_translator=self.default_server_error_translator,
+                exclude_none=exclude_none,
             )
         responses = {
             **build_openapi_responses(
@@ -405,6 +407,7 @@ class ErrorAwareRouter(APIRouter):
         warn_on_unmapped: bool = True,
         default_client_error_translator: Optional[ErrorTranslator[Any]] = None,
         default_server_error_translator: Optional[ErrorTranslator[Any]] = None,
+        exclude_none: bool = False,
         # --- FastAPI ---
         response_model: Any = Default(None),
         status_code: Optional[int] = None,
@@ -462,6 +465,7 @@ class ErrorAwareRouter(APIRouter):
                 default_on_error=default_on_error,
                 default_client_error_translator=default_client_error_translator,
                 default_server_error_translator=default_server_error_translator,
+                exclude_none=exclude_none,
                 response_model=response_model,
                 status_code=status_code,
                 tags=current_tags,
@@ -528,6 +532,7 @@ class ErrorAwareRouter(APIRouter):
         warn_on_unmapped: bool = True,
         default_client_error_translator: Optional[ErrorTranslator[Any]] = None,
         default_server_error_translator: Optional[ErrorTranslator[Any]] = None,
+        exclude_none: bool = False,
         # --- FastAPI ---
         response_model: Any = Default(None),
         status_code: Optional[int] = None,
@@ -564,6 +569,7 @@ class ErrorAwareRouter(APIRouter):
                 default_on_error=default_on_error,
                 default_client_error_translator=default_client_error_translator,
                 default_server_error_translator=default_server_error_translator,
+                exclude_none=exclude_none,
                 response_model=response_model,
                 status_code=status_code,
                 tags=tags,
@@ -612,6 +618,7 @@ class ErrorAwareRouter(APIRouter):
         warn_on_unmapped: bool = True,
         default_client_error_translator: Optional[ErrorTranslator[Any]] = None,
         default_server_error_translator: Optional[ErrorTranslator[Any]] = None,
+        exclude_none: bool = False,
         # --- FastAPI ---
         response_model: Annotated[
             Any,
@@ -957,6 +964,7 @@ class ErrorAwareRouter(APIRouter):
             default_on_error=default_on_error,
             default_client_error_translator=default_client_error_translator,
             default_server_error_translator=default_server_error_translator,
+            exclude_none=exclude_none,
             response_model=response_model,
             status_code=status_code,
             tags=tags,
@@ -1002,6 +1010,7 @@ class ErrorAwareRouter(APIRouter):
         warn_on_unmapped: bool = True,
         default_client_error_translator: Optional[ErrorTranslator[Any]] = None,
         default_server_error_translator: Optional[ErrorTranslator[Any]] = None,
+        exclude_none: bool = False,
         # --- FastAPI ---
         response_model: Annotated[
             Any,
@@ -1352,6 +1361,7 @@ class ErrorAwareRouter(APIRouter):
             default_on_error=default_on_error,
             default_client_error_translator=default_client_error_translator,
             default_server_error_translator=default_server_error_translator,
+            exclude_none=exclude_none,
             response_model=response_model,
             status_code=status_code,
             tags=tags,
@@ -1397,6 +1407,7 @@ class ErrorAwareRouter(APIRouter):
         warn_on_unmapped: bool = True,
         default_client_error_translator: Optional[ErrorTranslator[Any]] = None,
         default_server_error_translator: Optional[ErrorTranslator[Any]] = None,
+        exclude_none: bool = False,
         # --- FastAPI ---
         response_model: Annotated[
             Any,
@@ -1747,6 +1758,7 @@ class ErrorAwareRouter(APIRouter):
             default_on_error=default_on_error,
             default_client_error_translator=default_client_error_translator,
             default_server_error_translator=default_server_error_translator,
+            exclude_none=exclude_none,
             response_model=response_model,
             status_code=status_code,
             tags=tags,
@@ -1792,6 +1804,7 @@ class ErrorAwareRouter(APIRouter):
         warn_on_unmapped: bool = True,
         default_client_error_translator: Optional[ErrorTranslator[Any]] = None,
         default_server_error_translator: Optional[ErrorTranslator[Any]] = None,
+        exclude_none: bool = False,
         # --- FastAPI ---
         response_model: Annotated[
             Any,
@@ -2142,6 +2155,7 @@ class ErrorAwareRouter(APIRouter):
             default_on_error=default_on_error,
             default_client_error_translator=default_client_error_translator,
             default_server_error_translator=default_server_error_translator,
+            exclude_none=exclude_none,
             response_model=response_model,
             status_code=status_code,
             tags=tags,
@@ -2187,6 +2201,7 @@ class ErrorAwareRouter(APIRouter):
         warn_on_unmapped: bool = True,
         default_client_error_translator: Optional[ErrorTranslator[Any]] = None,
         default_server_error_translator: Optional[ErrorTranslator[Any]] = None,
+        exclude_none: bool = False,
         # --- FastAPI ---
         response_model: Annotated[
             Any,
@@ -2532,6 +2547,7 @@ class ErrorAwareRouter(APIRouter):
             default_on_error=default_on_error,
             default_client_error_translator=default_client_error_translator,
             default_server_error_translator=default_server_error_translator,
+            exclude_none=exclude_none,
             response_model=response_model,
             status_code=status_code,
             tags=tags,

--- a/src/fastapi_error_map/rules.py
+++ b/src/fastapi_error_map/rules.py
@@ -63,9 +63,14 @@ def resolve_rule_for_error(
         Callable[[Exception], Union[Awaitable[None], None]]
     ] = None,
 ) -> ResolvedRule:
-    try:
-        status_or_rule = error_map[type(error)]
-    except KeyError:
+    status_or_rule: Union[int, Rule, None] = None
+    for cls in type(error).mro():
+        if not issubclass(cls, Exception):
+            continue
+        if cls in error_map:
+            status_or_rule = error_map[cls]
+            break
+    if status_or_rule is None:
         raise RuntimeError(f"No rule defined for {type(error).__name__}") from error
 
     if isinstance(status_or_rule, int):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,12 +1,8 @@
 from collections.abc import AsyncIterator
-from contextlib import AbstractAsyncContextManager, asynccontextmanager
-from typing import Callable
 
+import httpx
 import pytest
 from fastapi import FastAPI
-from httpx import ASGITransport, AsyncClient
-
-AsgiClientFactory = Callable[[FastAPI], AbstractAsyncContextManager[AsyncClient]]
 
 
 @pytest.fixture
@@ -15,11 +11,9 @@ def app() -> FastAPI:
 
 
 @pytest.fixture
-def asgi_client_factory() -> AsgiClientFactory:
-    @asynccontextmanager
-    async def _make(app: FastAPI) -> AsyncIterator[AsyncClient]:
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            yield client
-
-    return _make
+async def client(app: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client

--- a/tests/integration/test_example.py
+++ b/tests/integration/test_example.py
@@ -1,22 +1,19 @@
-from typing import TYPE_CHECKING
-
+import httpx
 import pytest
 
 from examples.main import create_app
-from tests.integration.conftest import AsgiClientFactory
-
-if TYPE_CHECKING:
-    import httpx
 
 
 @pytest.mark.asyncio
 async def test_check_stock(
-    asgi_client_factory: AsgiClientFactory,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     app = create_app()
 
-    async with asgi_client_factory(app) as client:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
         authz_err_response: httpx.Response = await client.get("/stock?user_id=0")
         out_of_stock_err_response: httpx.Response = await client.get("/stock?user_id=1")
         openapi_response: httpx.Response = await client.get("/openapi.json")

--- a/tests/integration/test_exclude_none.py
+++ b/tests/integration/test_exclude_none.py
@@ -1,0 +1,85 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from fastapi_error_map import ErrorAwareRouter, rule
+from fastapi_error_map.translators import ErrorTranslator
+
+
+class CustomError(Exception):
+    pass
+
+
+@dataclass
+class ClientErrorWithOptionalDetails:
+    error: str
+    details: Optional[str] = None
+
+
+class OptionalDetailsTranslator(ErrorTranslator[ClientErrorWithOptionalDetails]):
+    @property
+    def error_response_model_cls(self) -> type[ClientErrorWithOptionalDetails]:
+        return ClientErrorWithOptionalDetails
+
+    def from_error(self, err: Exception) -> ClientErrorWithOptionalDetails:
+        return ClientErrorWithOptionalDetails(error=str(err), details=None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["get", "post", "put", "patch", "delete"])
+async def test_exclude_none_false_keeps_null_fields(
+    method: str,
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    router = ErrorAwareRouter()
+    translator = OptionalDetailsTranslator()
+
+    async def failing_endpoint() -> None:
+        await asyncio.sleep(0)
+        raise CustomError("boom")
+
+    getattr(router, method)(
+        "/fail",
+        error_map={CustomError: rule(status=418, translator=translator)},
+        exclude_none=False,
+    )(failing_endpoint)
+    app.include_router(router)
+
+    response: httpx.Response = await getattr(client, method)("/fail")
+
+    assert response.status_code == 418
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {"error": "boom", "details": None}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["get", "post", "put", "patch", "delete"])
+async def test_exclude_none_true_drops_null_fields(
+    method: str,
+    app: FastAPI,
+    client: httpx.AsyncClient,
+) -> None:
+    router = ErrorAwareRouter()
+    translator = OptionalDetailsTranslator()
+
+    async def failing_endpoint() -> None:
+        await asyncio.sleep(0)
+        raise CustomError("boom")
+
+    getattr(router, method)(
+        "/fail",
+        error_map={CustomError: rule(status=418, translator=translator)},
+        exclude_none=True,
+    )(failing_endpoint)
+    app.include_router(router)
+
+    response: httpx.Response = await getattr(client, method)("/fail")
+
+    assert response.status_code == 418
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {"error": "boom"}

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -145,6 +145,7 @@ async def test_handles_sync_on_error_from_map() -> None:
         default_client_error_translator=DefaultClientErrorTranslator(),
         default_server_error_translator=DefaultServerErrorTranslator(),
         default_on_error=None,
+        exclude_none=False,
     )
 
     assert sut.status_code == 422
@@ -163,6 +164,7 @@ async def test_handles_default_on_error_from_defaults() -> None:
         default_client_error_translator=DefaultClientErrorTranslator(),
         default_server_error_translator=DefaultServerErrorTranslator(),
         default_on_error=mock_on_error,
+        exclude_none=False,
     )
 
     assert sut.status_code == 422
@@ -181,6 +183,7 @@ async def test_handles_async_on_error() -> None:
         default_client_error_translator=DefaultClientErrorTranslator(),
         default_server_error_translator=DefaultServerErrorTranslator(),
         default_on_error=None,
+        exclude_none=False,
     )
 
     assert sut.status_code == 422
@@ -200,6 +203,7 @@ async def test_handles_async_on_error_partial() -> None:
         default_client_error_translator=DefaultClientErrorTranslator(),
         default_server_error_translator=DefaultServerErrorTranslator(),
         default_on_error=None,
+        exclude_none=False,
     )
 
     assert sut.status_code == 422
@@ -221,6 +225,7 @@ async def test_handles_sync_on_error_returning_awaitable() -> None:
         default_client_error_translator=DefaultClientErrorTranslator(),
         default_server_error_translator=DefaultServerErrorTranslator(),
         default_on_error=None,
+        exclude_none=False,
     )
 
     assert sut.status_code == 422

--- a/uv.lock
+++ b/uv.lock
@@ -405,7 +405,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-error-map"
-version = "0.9.8"
+version = "0.9.9"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
* Run sync endpoints in a threadpool
* Add MRO-based `error_map` resolution with fallback to parent exception classes
* Support excluding null fields in error responses